### PR TITLE
Add bgen support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,3 +78,18 @@ jobs:
       - name: Binary trait GWAS with retrieving vcf and indices via --input_folder_location
         run: |
           nextflow run ${GITHUB_WORKSPACE} --config conf/test_binary_with_input_folder.config
+  test_binary_bgen:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        nxf_ver: ['20.01.0', '']
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install Nextflow
+        run: |
+          export NXF_VER=${{ matrix.nxf_ver }}
+          wget -qO- get.nextflow.io | bash
+          sudo mv nextflow /usr/local/bin/
+      - name: Binary trait GWAS with retrieving bgen files and their indices
+        run: |
+          nextflow run ${GITHUB_WORKSPACE} --config conf/test_binary_with_input_folder.config

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        nxf_ver: ['20.01.0', '']
+        nxf_ver: ['20.01.0', '21.04.3']
     steps:
       - uses: actions/checkout@v1
       - name: Install Nextflow

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        nxf_ver: ['20.01.0', '21.04.3']
+        nxf_ver: ['20.01.0', '']
     steps:
       - uses: actions/checkout@v1
       - name: Install Nextflow
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        nxf_ver: ['20.01.0', '21.04.3']
+        nxf_ver: ['20.01.0', '']
     steps:
       - uses: actions/checkout@v1
       - name: Install Nextflow
@@ -92,4 +92,4 @@ jobs:
           sudo mv nextflow /usr/local/bin/
       - name: Binary trait GWAS with retrieving bgen files and their indices
         run: |
-          nextflow run ${GITHUB_WORKSPACE} --config conf/test_binary_with_input_folder.config
+          nextflow run ${GITHUB_WORKSPACE} --config conf/test_binary_bgen.config

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,48 @@ jobs:
       - name: Quantitative trait GWAS
         run: |
           nextflow run ${GITHUB_WORKSPACE} --config conf/test_qt.config
+  test_binary_prune_pca:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        nxf_ver: ['20.01.0', '']
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install Nextflow
+        run: |
+          export NXF_VER=${{ matrix.nxf_ver }}
+          wget -qO- get.nextflow.io | bash
+          sudo mv nextflow /usr/local/bin/
+      - name: Binary trait GWAS with creating LD-pruned files and PCA
+        run: |
+          nextflow run ${GITHUB_WORKSPACE} --config conf/test_binary_prune_pca.config
+  test_binary_prune_no_pca:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        nxf_ver: ['20.01.0', '']
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install Nextflow
+        run: |
+          export NXF_VER=${{ matrix.nxf_ver }}
+          wget -qO- get.nextflow.io | bash
+          sudo mv nextflow /usr/local/bin/
+      - name: Binary trait GWAS with creating LD-pruned files (without PCA step)
+        run: |
+          nextflow run ${GITHUB_WORKSPACE} --config conf/test_binary_prune_no_pca.config
+  test_binary_input_folder_location:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        nxf_ver: ['20.01.0', '']
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install Nextflow
+        run: |
+          export NXF_VER=${{ matrix.nxf_ver }}
+          wget -qO- get.nextflow.io | bash
+          sudo mv nextflow /usr/local/bin/
+      - name: Binary trait GWAS with retrieving vcf and indices via --input_folder_location
+        run: |
+          nextflow run ${GITHUB_WORKSPACE} --config conf/test_binary_with_input_folder.config

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        nxf_ver: ['20.01.0', '']
+        nxf_ver: ['20.01.0', '21.04.3']
     steps:
       - uses: actions/checkout@v1
       - name: Install Nextflow

--- a/README.md
+++ b/README.md
@@ -14,3 +14,5 @@ nextflow run main.nf \
   --trait_type "binary" \
   --genotype_files_list "s3://lifebit-featured-datasets/projects/gel/gel-gwas/testdata/vcfs.csv" \
 ```
+
+P.S. The maximum memory used by plink is `16Gb`. If more memory needs to be assigned to plink commands, please use `--plink_memory` parameter to adjust accordingly.

--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ nextflow run main.nf \
   --genotype_files_list "s3://lifebit-featured-datasets/projects/gel/gel-gwas/testdata/vcfs.csv" \
 ```
 
-P.S. The maximum memory used by plink is `16Gb`. If more memory needs to be assigned to plink commands, please use `--plink_memory` parameter to adjust accordingly.
+P.S. maximum RAM assigned to plink operations is set to  `16Gb` by default. If more memory needs to be assigned to plink commands, please use `--plink_memory` parameter to adjust accordingly.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Example run using VCF files as input:
 ```bash
 nextflow run main.nf \
   --grm_plink_input "s3://lifebit-featured-datasets/projects/gel/gel-gwas/testdata/sampleA.{bed,bim,fam}" \
-  --pheno_data "s3://lifebit-featured-datasets/projects/gel/cb_binary_pheno.phe" \
+  --pheno_data "s3://lifebit-featured-datasets/projects/gel/gel-gwas/cb_binary_pheno.phe" \
   --trait_type "binary" \
   --genotype_files_list "s3://lifebit-featured-datasets/projects/gel/gel-gwas/testdata/vcfs.csv" \
 ```

--- a/README.md
+++ b/README.md
@@ -14,3 +14,5 @@ nextflow run main.nf \
   --trait_type "binary" \
   --genotype_files_list "s3://lifebit-featured-datasets/projects/gel/gel-gwas/testdata/vcfs.csv" \
 ```
+
+P.S. maximum RAM assigned to plink operations is set to  `16Gb` by default. If more memory needs to be assigned to plink commands, please use `--plink_memory` parameter to adjust accordingly.

--- a/README.md
+++ b/README.md
@@ -14,5 +14,3 @@ nextflow run main.nf \
   --trait_type "binary" \
   --genotype_files_list "s3://lifebit-featured-datasets/projects/gel/gel-gwas/testdata/vcfs.csv" \
 ```
-
-P.S. maximum RAM assigned to plink operations is set to  `16Gb` by default. If more memory needs to be assigned to plink commands, please use `--plink_memory` parameter to adjust accordingly.

--- a/README.md
+++ b/README.md
@@ -3,12 +3,14 @@
 ![](bin/covid_1_manhattan.png)
 
 ## Example usage
-Read more about parameters [here](https://github.com/lifebit-ai/gwas/docs/usage_and_parameters.md)
+Read more about parameters [here](https://github.com/lifebit-ai/gwas/blob/dev/docs/usage_and_parameters.md)
+
+Example run using VCF files as input:
 
 ```bash
 nextflow run main.nf \
   --grm_plink_input "s3://lifebit-featured-datasets/projects/gel/gel-gwas/testdata/sampleA.{bed,bim,fam}" \
-  --pheno_data "s3://marcos-lifebit/gel-gwas/cb_binary_pheno.phe" \
+  --pheno_data "s3://lifebit-featured-datasets/projects/gel/cb_binary_pheno.phe" \
   --trait_type "binary" \
-  --vcfs_list "s3://lifebit-featured-datasets/projects/gel/gel-gwas/testdata/vcfs.csv" \
+  --genotype_files_list "s3://lifebit-featured-datasets/projects/gel/gel-gwas/testdata/vcfs.csv" \
 ```

--- a/bin/concat_covariates.R
+++ b/bin/concat_covariates.R
@@ -1,0 +1,87 @@
+#!/usr/bin/env Rscript
+
+############################## ARGUMENTS SECTION #############################
+## Collect arguments
+args <- commandArgs(TRUE)
+
+## Default setting when no all arguments passed or help needed
+if("--help" %in% args | "help" %in% args | (length(args) == 0) | (length(args) == 1) ) {
+  cat("
+      The helper R Script concat_covariates.R
+
+      Mandatory arguments:
+        --pcs_file         - Path to file containing eigenvectors from PCA step (output of plink --pca command).
+
+        --phenotype_file        - Path to file containing phenotype of interest and covariates. Supplied via --pheno_data to the pipeline.
+
+        --output_file           - Path to resultant file with phenotype, covariates and PCs combined.
+
+         --help                    - helpful documentation.
+
+
+     Usage:
+
+          The typical command for running the script is as follows:
+
+          ./concat_covariates.R --pcs_file='pca_results.eigenvec' --phenotype_file='pheno_and_covariates.tsv' --output_file='full_covariates_pheno_files.tsv'
+
+     Output:
+
+      Returns a single .tsv file {saige_output_name}_{output_tag}.csv with covariates, phenotype of interest and PCs combined into one file.
+
+      See ./concat_covariates.R --help for more details.
+
+      \n")
+
+  q(save="no")
+}
+
+## Parse arguments (we expect the form --arg=value)
+parseArgs    <- function(x) strsplit(sub("^--", "", x), "=")
+
+argsL        <- as.list(as.character(as.data.frame(do.call("rbind", parseArgs(args)))$V2))
+names(argsL) <- as.data.frame(do.call("rbind", parseArgs(args)))$V1
+args         <- argsL
+rm(argsL)
+
+
+## Give some value to optional arguments if not provided
+# if(is.null(args$filename_pattern)) {args$filename_pattern = ".SAIGE.gwas.txt"} else {args$filename_pattern=as.character(args$filename_pattern)}
+# if(is.null(args$saige_output_name)) {args$saige_output_name = "saige_results"} else {args$saige_output_name=as.character(args$saige_output_name)}
+# if(is.null(args$top_n_sites)) {args$top_n_sites = 200} else {args$top_n_sites=as.numeric(args$top_n_sites)}
+# if(is.null(args$max_top_n_sites)) {args$max_top_n_sites = 1000} else {args$max_top_n_sites=as.numeric(args$max_top_n_sites)}
+
+############################## LIBRARIES SECTION #############################
+
+suppressWarnings(suppressMessages(library(plyr)))
+suppressWarnings(suppressMessages(library(data.table)))
+suppressWarnings(suppressMessages(library(snakecase)))
+suppressWarnings(suppressMessages(library(dplyr)))
+
+# ######################### VARIABLES REASSIGNMENT SECTION ###############################
+
+# Facilitates testing and protects from wh-spaces, irregular chars
+
+pcs_file <- as.character(args$pcs_file)
+phenotype_file <- as.character(args$phenotype_file)
+output_file <- as.character(args$output_file)
+
+
+cat("\n")
+cat("ARGUMENTS SUMMARY")
+cat("\n")
+cat("pcs_file         : ", pcs_file         ,"\n",sep="")
+cat("phenotype_file   : ", phenotype_file   ,"\n",sep="")
+cat("output_file  : ", output_file  ,"\n",sep="")
+
+
+# ############################### SCRIPT SECTION ###############################
+
+principal_components = fread(pcs_file)
+covariates_file = fread(phenotype_file)
+
+output_df <- dplyr::left_join(principal_components, covariates_file, by='IID')
+data.table::fwrite(output_df, "covariates_with_PCs.tsv", sep = "\t")
+
+
+

--- a/bin/qqplot.R
+++ b/bin/qqplot.R
@@ -113,7 +113,7 @@ png(filename =  paste0(output_tag,"_", "qqplot_ci" , ".png") ,
     type   = type)
 
 
-GWASTools::qqPlot(analysis$P, main=paste0(output_tag,",","lambda=",round(lambda(analysis$P),2)))
+GWASTools::qqPlot(analysis$P, main=paste0(output_tag,",","\u03BB = ",round(lambda(analysis$P),2)))
 dev.off()
 
 #check whether we can just save the R objects and also give the option for exporting through a future airlock

--- a/conf/base.config
+++ b/conf/base.config
@@ -1,0 +1,66 @@
+process {
+
+  errorStrategy = { task.exitStatus in [143,137,104,134,139] ? 'retry' : 'terminate' }
+  maxRetries = 1
+  maxErrors = '-1'
+
+  // Process-specific resource requirements
+  withLabel: tiny_memory {
+    cpus = { check_max (4, 'cpus')}
+    memory = { check_max( 10.GB * task.attempt, 'memory' ) }
+    time = { check_max( 8.h * task.attempt, 'time' ) }
+  }
+  withLabel: low_memory {
+    cpus = { check_max (8, 'cpus')}
+    memory = { check_max( 20.GB * task.attempt, 'memory' ) }
+    time = { check_max( 8.h * task.attempt, 'time' ) }
+  }
+  withLabel: mid_memory {
+    cpus = { check_max (8, 'cpus')}
+    memory = { check_max( 30.GB * task.attempt, 'memory' ) }
+    time = { check_max( 16.h * task.attempt, 'time' ) }
+  }
+  withLabel: high_memory {
+    cpus = { check_max (20, 'cpus')}
+    memory = { check_max( 60.GB * task.attempt, 'memory' ) }
+    time = { check_max( 8.h * task.attempt, 'time' ) }
+  }
+  withLabel: mega_memory {
+    cpus = { check_max (24, 'cpus')}
+    memory = { check_max( 120.GB * task.attempt, 'memory' ) }
+    time = { check_max( 20.h * task.attempt, 'time' ) }
+  }
+}
+
+// Function to ensure that resource requirements don't go beyond
+// a maximum limit
+def check_max(obj, type) {
+  if (type == 'memory') {
+    try {
+      if (obj.compareTo(params.max_memory as nextflow.util.MemoryUnit) == 1)
+        return params.max_memory as nextflow.util.MemoryUnit
+      else
+        return obj
+    } catch (all) {
+      println "   ### ERROR ###   Max memory '${params.max_memory}' is not valid! Using default value: $obj"
+      return obj
+    }
+  } else if (type == 'time') {
+    try {
+      if (obj.compareTo(params.max_time as nextflow.util.Duration) == 1)
+        return params.max_time as nextflow.util.Duration
+      else
+        return obj
+    } catch (all) {
+      println "   ### ERROR ###   Max time '${params.max_time}' is not valid! Using default value: $obj"
+      return obj
+    }
+  } else if (type == 'cpus') {
+    try {
+      return Math.min( obj, params.max_cpus as int )
+    } catch (all) {
+      println "   ### ERROR ###   Max cpus '${params.max_cpus}' is not valid! Using default value: $obj"
+      return obj
+    }
+  }
+}

--- a/conf/test_binary.config
+++ b/conf/test_binary.config
@@ -16,7 +16,7 @@ params  {
     grm_plink_input = "testdata/plink/sampleA.{bed,bim,fam}"
     pheno_data = "s3://marcos-lifebit/gel-gwas/cb_binary_pheno.phe"
     trait_type = "binary"
-    vcfs_list = "s3://lifebit-featured-datasets/projects/gel/gel-gwas/testdata/vcfs.csv"
+    genotype_files_list = "s3://lifebit-featured-datasets/projects/gel/gel-gwas/testdata/vcfs.csv"
 
 
     // Limit resources so that this can run on GitHub Actions

--- a/conf/test_binary_bgen.config
+++ b/conf/test_binary_bgen.config
@@ -19,6 +19,7 @@ params  {
     genotype_files_list = "/home/ubuntu/git/gwas/bgen_files/bgen_design_file.csv"
     genotype_format = "bgen"
     bgen_sample_file = "/home/ubuntu/git/gwas/bgen_files/from_plink.sample"
+    p_significance_threshold = 1
 
 
     // Limit resources so that this can run on GitHub Actions

--- a/conf/test_binary_bgen.config
+++ b/conf/test_binary_bgen.config
@@ -12,13 +12,12 @@
 docker.enabled = true
 
 params  {
-
     grm_plink_input = "testdata/plink/sampleA.{bed,bim,fam}"
-    pheno_data = "s3://lifebit-featured-datasets/projects/gel/gel-gwas/cb_binary_pheno.phe"
+    pheno_data = "https://lifebit-featured-datasets.s3-eu-west-1.amazonaws.com/projects/gel/gel-gwas/cb_binary_pheno.phe"
     trait_type = "binary"
-    genotype_files_list = "s3://lifebit-gwas/testdata/bgen/bgen_files.csv"
+    genotype_files_list = "https://lifebit-gwas.s3-eu-west-1.amazonaws.com/testdata/bgen/bgen_files.csv"
     genotype_format = "bgen"
-    bgen_sample_file = "s3://lifebit-gwas/testdata/bgen/all_chr.sample"
+    bgen_sample_file = "https://lifebit-gwas.s3-eu-west-1.amazonaws.com/testdata/bgen/all_chr.sample"
     p_significance_threshold = 0.5
 
 

--- a/conf/test_binary_bgen.config
+++ b/conf/test_binary_bgen.config
@@ -1,0 +1,26 @@
+/*
+ * -----------------------------------------------------------------
+ *  lifebit-ai/gwas test config file
+ * -----------------------------------------------------------------
+ * Defines bundled input files and everything required
+ * to run a fast and simple test. Use as follows:
+ * nextflow run main.nf -profile test_binary_bgen
+
+ */
+
+
+docker.enabled = true
+
+params  {
+
+    grm_plink_input = "testdata/plink/sampleA.{bed,bim,fam}"
+    pheno_data = "s3://marcos-lifebit/gel-gwas/cb_binary_pheno.phe"
+    trait_type = "binary"
+    genotype_files_list = "/home/ubuntu/git/gwas/bgen_files/bgen_design_file.csv"
+    genotype_format = "bgen"
+    bgen_sample_file = "/home/ubuntu/git/gwas/bgen_files/from_plink.sample"
+
+
+    // Limit resources so that this can run on GitHub Actions
+    max_cpus = 2
+}

--- a/conf/test_binary_bgen.config
+++ b/conf/test_binary_bgen.config
@@ -14,12 +14,12 @@ docker.enabled = true
 params  {
 
     grm_plink_input = "testdata/plink/sampleA.{bed,bim,fam}"
-    pheno_data = "s3://marcos-lifebit/gel-gwas/cb_binary_pheno.phe"
+    pheno_data = "s3://lifebit-featured-datasets/projects/gel/gel-gwas/cb_binary_pheno.phe"
     trait_type = "binary"
-    genotype_files_list = "/home/ubuntu/git/gwas/bgen_files/bgen_design_file.csv"
+    genotype_files_list = "s3://lifebit-gwas/testdata/bgen/bgen_files.csv"
     genotype_format = "bgen"
-    bgen_sample_file = "/home/ubuntu/git/gwas/bgen_files/from_plink.sample"
-    p_significance_threshold = 1
+    bgen_sample_file = "s3://lifebit-gwas/testdata/bgen/all_chr.sample"
+    p_significance_threshold = 0.5
 
 
     // Limit resources so that this can run on GitHub Actions

--- a/conf/test_binary_prune_no_pca.config
+++ b/conf/test_binary_prune_no_pca.config
@@ -1,0 +1,24 @@
+/*
+ * -----------------------------------------------------------------
+ *  lifebit-ai/gwas test config file
+ * -----------------------------------------------------------------
+ * Defines bundled input files and everything required
+ * to run a fast and simple test. Use as follows:
+ * nextflow run main.nf -profile test_binary_prune_no_pca
+
+ */
+
+
+docker.enabled = true
+
+params  {
+
+    pheno_data = "s3://marcos-lifebit/gel-gwas/cb_binary_pheno.phe"
+    trait_type = "binary"
+    vcfs_list = "s3://lifebit-featured-datasets/projects/gel/gel-gwas/testdata/vcfs.csv"
+    run_pca = false
+
+
+    // Limit resources so that this can run on GitHub Actions
+    max_cpus = 2
+}

--- a/conf/test_binary_prune_no_pca.config
+++ b/conf/test_binary_prune_no_pca.config
@@ -15,7 +15,7 @@ params  {
 
     pheno_data = "s3://marcos-lifebit/gel-gwas/cb_binary_pheno.phe"
     trait_type = "binary"
-    vcfs_list = "s3://lifebit-featured-datasets/projects/gel/gel-gwas/testdata/vcfs.csv"
+    genotype_files_list = "s3://lifebit-featured-datasets/projects/gel/gel-gwas/testdata/vcfs.csv"
     run_pca = false
 
 

--- a/conf/test_binary_prune_pca.config
+++ b/conf/test_binary_prune_pca.config
@@ -1,0 +1,24 @@
+/*
+ * -----------------------------------------------------------------
+ *  lifebit-ai/gwas test config file
+ * -----------------------------------------------------------------
+ * Defines bundled input files and everything required
+ * to run a fast and simple test. Use as follows:
+ * nextflow run main.nf -profile test_binary_prune_pca
+
+ */
+
+
+docker.enabled = true
+
+params  {
+
+    pheno_data = "s3://marcos-lifebit/gel-gwas/cb_binary_pheno.phe"
+    trait_type = "binary"
+    vcfs_list = "s3://lifebit-featured-datasets/projects/gel/gel-gwas/testdata/vcfs.csv"
+    run_pca = true
+
+
+    // Limit resources so that this can run on GitHub Actions
+    max_cpus = 2
+}

--- a/conf/test_binary_prune_pca.config
+++ b/conf/test_binary_prune_pca.config
@@ -15,7 +15,7 @@ params  {
 
     pheno_data = "s3://marcos-lifebit/gel-gwas/cb_binary_pheno.phe"
     trait_type = "binary"
-    vcfs_list = "s3://lifebit-featured-datasets/projects/gel/gel-gwas/testdata/vcfs.csv"
+    genotype_files_list = "s3://lifebit-featured-datasets/projects/gel/gel-gwas/testdata/vcfs.csv"
     run_pca = true
 
 

--- a/conf/test_binary_with_input_folder.config
+++ b/conf/test_binary_with_input_folder.config
@@ -1,6 +1,6 @@
 /*
  * -----------------------------------------------------------------
- *  lifebit-ai/gel-gwas test config file
+ *  lifebit-ai/gwas test config file
  * -----------------------------------------------------------------
  * Defines bundled input files and everything required
  * to run a fast and simple test. Use as follows:
@@ -14,7 +14,7 @@ docker.enabled = true
 params  {
 
     grm_plink_input = "testdata/plink/sampleA.{bed,bim,fam}"
-    pheno_data = "s3://marcos-lifebit/gel-gwas/cb_binary_pheno.phe"
+    pheno_data = "s3://lifebit-featured-datasets/projects/gel/gel-gwas/cb_binary_pheno.phe"
     trait_type = "binary"
     input_folder_location = "s3://lifebit-featured-datasets/projects/gel/gel-gwas/testdata/vcfs/"
     file_pattern = "sampleA"

--- a/conf/test_binary_with_input_folder.config
+++ b/conf/test_binary_with_input_folder.config
@@ -14,9 +14,9 @@ docker.enabled = true
 params  {
 
     grm_plink_input = "testdata/plink/sampleA.{bed,bim,fam}"
-    pheno_data = "s3://lifebit-featured-datasets/projects/gel/gel-gwas/cb_binary_pheno.phe"
+    pheno_data = "https://lifebit-featured-datasets.s3-eu-west-1.amazonaws.com/projects/gel/gel-gwas/cb_binary_pheno.phe"
     trait_type = "binary"
-    input_folder_location = "s3://lifebit-featured-datasets/projects/gel/gel-gwas/testdata/vcfs/"
+    input_folder_location = "https://lifebit-featured-datasets.s3-eu-west-1.amazonaws.com/projects/gel/gel-gwas/testdata/vcfs/"
     file_pattern = "sampleA"
     file_suffix = "vcf.gz"
     index_suffix = "vcf.gz.csi"

--- a/conf/test_binary_with_input_folder.config
+++ b/conf/test_binary_with_input_folder.config
@@ -1,0 +1,28 @@
+/*
+ * -----------------------------------------------------------------
+ *  lifebit-ai/gel-gwas test config file
+ * -----------------------------------------------------------------
+ * Defines bundled input files and everything required
+ * to run a fast and simple test. Use as follows:
+ * nextflow run main.nf -profile test_binary_with_input_folder
+
+ */
+
+
+docker.enabled = true
+
+params  {
+
+    grm_plink_input = "testdata/plink/sampleA.{bed,bim,fam}"
+    pheno_data = "s3://marcos-lifebit/gel-gwas/cb_binary_pheno.phe"
+    trait_type = "binary"
+    input_folder_location = "s3://lifebit-featured-datasets/projects/gel/gel-gwas/testdata/vcfs/"
+    file_pattern = "sampleA"
+    file_suffix = "vcf.gz"
+    index_suffix = "vcf.gz.csi"
+    number_of_files_to_process = 22
+
+
+    // Limit resources so that this can run on GitHub Actions
+    max_cpus = 2
+}

--- a/conf/test_binary_with_input_folder.config
+++ b/conf/test_binary_with_input_folder.config
@@ -16,7 +16,7 @@ params  {
     grm_plink_input = "testdata/plink/sampleA.{bed,bim,fam}"
     pheno_data = "https://lifebit-featured-datasets.s3-eu-west-1.amazonaws.com/projects/gel/gel-gwas/cb_binary_pheno.phe"
     trait_type = "binary"
-    input_folder_location = "https://lifebit-featured-datasets.s3-eu-west-1.amazonaws.com/projects/gel/gel-gwas/testdata/vcfs/"
+    input_folder_location = "s3://lifebit-featured-datasets/projects/gel/gel-gwas/testdata/vcfs/"
     file_pattern = "sampleA"
     file_suffix = "vcf.gz"
     index_suffix = "vcf.gz.csi"

--- a/conf/test_qt.config
+++ b/conf/test_qt.config
@@ -15,7 +15,7 @@ params  {
     grm_plink_input = "testdata/plink/sampleA.{bed,bim,fam}"
     pheno_data = "s3://marcos-lifebit/gel-gwas/cb_qt_pheno.phe"
     trait_type = "quantitative"
-    vcfs_list = "s3://lifebit-featured-datasets/projects/gel/gel-gwas/testdata/vcfs.csv"
+    genotype_files_list = "s3://lifebit-featured-datasets/projects/gel/gel-gwas/testdata/vcfs.csv"
 
 
     // Limit resources so that this can run on GitHub Actions

--- a/docs/usage_and_parameters.md
+++ b/docs/usage_and_parameters.md
@@ -27,7 +27,14 @@ nextflow run main.nf \
 ## **ESSENTIAL**
 
 - **--vcfs_list** : path/url to CSV file containing chr chunk information, path to aggregated VCFs, VCFs index.
-- **--grm_plink_input** : path/url to folder that contains bed, bim, fam files for aggregated VCFs.
+
+OR vcf files can be supplied using:
+
+- **--input_folder_location** : s3 path to location of VCF files.
+- **--number_of_files_to_process** : Number of VCF files and corresponding indices to use from the s3 path. (_Default: -1, which corresponds to all files_ )
+- **--file_pattern** : Filename pattern of VCF files and corresponding indices within the s3 path supplied via `--input_folder_location`.
+
+
 - **--pheno_data** : path/url to file that contains phenotypic information about cohort to be analysed in plink phenotypic format (.phe).
 
 ## **Binary**
@@ -41,19 +48,32 @@ nextflow run main.nf \
 
 ## **Optional**
 
+- **--phenotype_colname** :  Column name of phenotype as shown in file supplied via `--pheno_data`. Default=`"PHE"`
+
 - **--q_filter** : Minimum allele frequency filter for selecting sites.
 - **--thres_m** : Minimum threshold for missingess.
 - **--hwe_threshold** : Significance threshold for Hardy-Weinberg Equilibrium. Default = 1e-5
-- **--hwe_test** : Type of test done for Hardy-Weinberge Equilibrium. Default = 'midp' which stands for the mid-p adjustmenttends (plink's recommended option). Favours filter of variants with more missing data.
+- **--hwe_test** : Type of test done for Hardy-Weinberge Equilibrium. Default = 'midp' which stands for the mid-p adjustment (plink's recommended option). Favours filtering of variants with more missing data.
 
 - **--ld_window_size** Default = 50. Window size for LD-pruning.
 - **--ld_step_size** Default = 10. Step size for LD-pruning.
 - **--ld_r2_threshold** Default = 0.1. R2 correlation threshold for LD-pruning.
+
+- **--grm_plink_input** : path/url to folder that contains bed, bim, fam files for aggregated VCFs. This should be a set of LD-pruned genome-wide plink files containing high-quality/genotyped SNPs. If not provided, the workflow will use input VCF files to merge, LD-prune and convert to plink format. This set of plink files is used in first step of SAIGE for estimating relatedness.
+
+- **--run_pca** : Run PCA and use principal components as covariates in GWAS. Default=`true`.
+- **--number_pcs** : Number of principal components generated ans used in GWAS. Default=`10`.
 
 - **--saige_step1_extra_flags** : Additional flags for SAIGE, they should be formatted as "--LOCO=FALSE".
 - **--outdir** : Output directory for results.
 - **--gwas_cat** : Path to GWAS catalog CSV file. Defaults to 's3://lifebit-featured-datasets/projects/gel/gel-gwas/gwascat.csv'.
 - **--output_tag** : Prefix to identify output files.
 - **--top_n_sites** : Minimum number of top sites to be included in output.
+- **--p_significance_threshold** : P-value significance threshold for Manhattan plot annotations.
 - **--max_top_n_sites** : Maximum number of top sites to be included in output.
 - **--saige_filename_pattern** : File pattern specifically for SAIGE files.
+
+
+- **--file_suffix** : File extension of main files supplied via --input_folder_location if used. Default=`"vcf.gz"`
+- **--index_suffix** : File extension of index files supplied via --input_folder_location if used. Default=`"vcf.gz.csi"`
+

--- a/docs/usage_and_parameters.md
+++ b/docs/usage_and_parameters.md
@@ -26,7 +26,7 @@ nextflow run main.nf \
 
 ## **ESSENTIAL**
 
-- **--vcfs_list** : path/url to CSV file containing chr chunk information, path to aggregated VCFs, VCFs index.
+- **--genotype_files_list** : path/url to CSV file containing chr, path to file and corresponding index, e.g. for VCF - chr,vcf,index(.csi) and for .bgen files - chr,bgen,index(.bgi).
 
 OR vcf files can be supplied using:
 
@@ -37,18 +37,14 @@ OR vcf files can be supplied using:
 
 - **--pheno_data** : path/url to file that contains phenotypic information about cohort to be analysed in plink phenotypic format (.phe).
 
-## **Binary**
-
-- **--trait_type** : Should be set as 'binary'.
-
-## **Quantitative**
-
-- **--trait_type** : Should be set to 'quantitative'.
+- **--trait_type** : Should be set to 'quantitative' or 'binary', depending on the trait of interest.
 
 
 ## **Optional**
 
 - **--phenotype_colname** :  Column name of phenotype as shown in file supplied via `--pheno_data`. Default=`"PHE"`
+- **--genotype_format** : Format of genotype files in input. Default=`"vcf`. Currently supported options are `"vcf"` and `"bgen"`.
+- **--bgen_sample_file**: Sample file accompanying bgen files. Only required if genotype files are in .bgen format. Used in bgen->plink conversion.
 
 - **--q_filter** : Minimum allele frequency filter for selecting sites.
 - **--thres_m** : Minimum threshold for missingess.

--- a/docs/usage_and_parameters.md
+++ b/docs/usage_and_parameters.md
@@ -76,3 +76,4 @@ OR vcf files can be supplied using:
 - **--file_suffix** : File extension of main files supplied via --input_folder_location if used. Default=`"vcf.gz"`
 - **--index_suffix** : File extension of index files supplied via --input_folder_location if used. Default=`"vcf.gz.csi"`
 
+- **--plink_memory** : By default, plink tries to reserve half of available RAM for its main workspace. If this amount is insufficient for your current job, you can use this parameter to adjust this behavior.

--- a/docs/usage_and_parameters.md
+++ b/docs/usage_and_parameters.md
@@ -9,7 +9,7 @@ nextflow run main.nf \
   --grm_plink_input "s3://lifebit-featured-datasets/projects/gel/gel-gwas/testdata/sampleA.{bed,bim,fam}" \
   --pheno_data "<pheno_file>" \
   --trait_type "binary" \
-  --vcfs_list "s3://lifebit-featured-datasets/projects/gel/gel-gwas/testdata/vcfs.csv"
+  --genotype_files_list "s3://lifebit-featured-datasets/projects/gel/gel-gwas/testdata/vcfs.csv"
 ```
 
 **Quantitative**
@@ -19,7 +19,7 @@ nextflow run main.nf \
   --grm_plink_input "s3://lifebit-featured-datasets/projects/gel/gel-gwas/testdata/sampleA.{bed,bim,fam}" \
   --pheno_data "<pheno_file>" \
   --trait_type "quantitative" \
-  --vcfs_list "s3://lifebit-featured-datasets/projects/gel/gel-gwas/testdata/vcfs.csv"
+  --genotype_files_list "s3://lifebit-featured-datasets/projects/gel/gel-gwas/testdata/vcfs.csv"
 ```
 
 # Parameters
@@ -42,8 +42,8 @@ OR vcf files can be supplied using:
 
 ## **Optional**
 
-- **--phenotype_colname** :  Column name of phenotype as shown in file supplied via `--pheno_data`. Default=`"PHE"`
-- **--genotype_format** : Format of genotype files in input. Default=`"vcf`. Currently supported options are `"vcf"` and `"bgen"`.
+- **--phenotype_colname** :  Column name of phenotype as shown in file supplied via `--pheno_data`. Default=`PHE`
+- **--genotype_format** : Format of genotype files in input. Default=`"vcf`. Currently supported options are `vcf` and `bgen`. Default=`vcf`.
 - **--bgen_sample_file**: Sample file accompanying bgen files. Only required if genotype files are in .bgen format. Used in bgen->plink conversion.
 
 - **--q_filter** : Minimum allele frequency filter for selecting sites.

--- a/docs/usage_and_parameters.md
+++ b/docs/usage_and_parameters.md
@@ -76,4 +76,3 @@ OR vcf files can be supplied using:
 - **--file_suffix** : File extension of main files supplied via --input_folder_location if used. Default=`"vcf.gz"`
 - **--index_suffix** : File extension of index files supplied via --input_folder_location if used. Default=`"vcf.gz.csi"`
 
-- **--plink_memory** : By default, plink tries to reserve half of available RAM for its main workspace. If this amount is insufficient for your current job, you can use this parameter to adjust this behavior.

--- a/main.nf
+++ b/main.nf
@@ -164,38 +164,38 @@ if (params.run_pca) {
   ---------------------------------------------------*/
 if (params.genotype_format == 'vcf') {
   process vcf2plink {
-  tag "$name"
-  label 'high_memory'
-  publishDir "${params.outdir}/gwas_filtering", mode: 'copy'
+    tag "$name"
+    label 'high_memory'
+    publishDir "${params.outdir}/gwas_filtering", mode: 'copy'
 
-  input:
-  set val(name), val(chr), file(vcf), file(index) from inputVcfCh
-  each file(phe_file) from ch_pheno_vcf2plink
+    input:
+    set val(name), val(chr), file(vcf), file(index) from inputVcfCh
+    each file(phe_file) from ch_pheno_vcf2plink
 
-  output:
-  set val(name), val(chr), file('*.bed'), file('*.bim'), file('*.fam') into filteredPlinkCh
+    output:
+    set val(name), val(chr), file('*.bed'), file('*.bim'), file('*.fam') into filteredPlinkCh
 
-  script:
-  """
-  # Download, filter and convert (bcf or vcf.gz) -> vcf.gz
-  tail -n +2 ${phe_file}| cut -f2 > samples.txt
-  bcftools view -S samples.txt $vcf -Oz -o ${name}_downsampled.vcf.gz
-  bcftools view -q ${params.q_filter} ${name}_downsampled.vcf.gz -Oz -o ${name}_filtered.vcf.gz
-  bcftools index ${name}_filtered.vcf.gz
+    script:
+    """
+    # Download, filter and convert (bcf or vcf.gz) -> vcf.gz
+    tail -n +2 ${phe_file}| cut -f2 > samples.txt
+    bcftools view -S samples.txt $vcf -Oz -o ${name}_downsampled.vcf.gz
+    bcftools view -q ${params.q_filter} ${name}_downsampled.vcf.gz -Oz -o ${name}_filtered.vcf.gz
+    bcftools index ${name}_filtered.vcf.gz
 
-  # Create PLINK binary from vcf.gz
-  plink2 \
-    --make-bed \
-    --set-missing-var-ids @:#,\\\$r,\\\$a \
-    --vcf ${name}_filtered.vcf.gz \
-    --out ${name}_filtered \
-    --vcf-half-call m \
-    --memory ${params.plink_memory} \
-    --double-id \
-    --set-hh-missing \
-    --new-id-max-allele-len 60 missing
-"""   
-}
+    # Create PLINK binary from vcf.gz
+    plink2 \
+      --make-bed \
+      --set-missing-var-ids @:#,\\\$r,\\\$a \
+      --vcf ${name}_filtered.vcf.gz \
+      --out ${name}_filtered \
+      --vcf-half-call m \
+      --memory ${params.plink_memory} \
+      --double-id \
+      --set-hh-missing \
+      --new-id-max-allele-len 60 missing
+  """   
+  }
 }
 else if (params.genotype_format == 'bgen') {
   process bgen2plink {
@@ -207,26 +207,25 @@ else if (params.genotype_format == 'bgen') {
     each file(phe_file) from ch_pheno_bgen
     each file(sample_file) from ch_bgen_sample_file
 
-  output:
-  set val(name), val(chr), file('*.bed'), file('*.bim'), file('*.fam') into filteredPlinkCh
+    output:
+    set val(name), val(chr), file('*.bed'), file('*.bim'), file('*.fam') into filteredPlinkCh
 
-  script:
-  """
-  # Create a sample ID file for --keep
-  tail -n +2 ${phe_file}| cut -f1,2 > samples.txt
+    script:
+    """
+    # Create a sample ID file for --keep
+    tail -n +2 ${phe_file}| cut -f1,2 > samples.txt
 
-  # Create PLINK binary from vcf.gz
-  plink2 \
-    --make-bed \
-    --bgen ${bgen}\
-    --out ${name}_filtered \
-    --maf ${params.maf_filter} \
-    --double-id \
-    --memory ${params.plink_memory} \
-    --keep samples.txt \
-    --sample ${sample_file}
-  """ 
-
+    # Create PLINK binary from vcf.gz
+    plink2 \
+      --make-bed \
+      --bgen ${bgen}\
+      --out ${name}_filtered \
+      --maf ${params.maf_filter} \
+      --double-id \
+      --memory ${params.plink_memory} \
+      --keep samples.txt \
+      --sample ${sample_file}
+    """ 
   }
 }
 

--- a/main.nf
+++ b/main.nf
@@ -200,7 +200,6 @@ if (params.genotype_format == 'vcf') {
 else if (params.genotype_format == 'bgen') {
   process bgen2plink {
     tag "$name"
-    label 'mega_memory'
     publishDir "${params.outdir}/gwas_filtering", mode: 'copy'
 
     input:

--- a/main.nf
+++ b/main.nf
@@ -190,6 +190,7 @@ if (params.genotype_format == 'vcf') {
       --vcf ${name}_filtered.vcf.gz \
       --out ${name}_filtered \
       --vcf-half-call m \
+      --memory ${params.plink_memory} \
       --double-id \
       --set-hh-missing \
       --new-id-max-allele-len 60 missing
@@ -221,6 +222,7 @@ else if (params.genotype_format == 'bgen') {
       --out ${name}_filtered \
       --maf ${params.maf_filter} \
       --double-id \
+      --memory ${params.plink_memory} \
       --keep samples.txt \
       --sample ${sample_file}
     """ 
@@ -246,6 +248,7 @@ process filter_missingness {
      --pheno-name ${params.phenotype_colname} \
      --allow-no-sex \
      --test-missing midp \
+     --memory ${params.plink_memory} \
      --out ${name} \
      --1 \
      --keep-allele-order \
@@ -256,6 +259,7 @@ process filter_missingness {
      --keep-allele-order \
      --allow-no-sex \
      --exclude ${name}.missing_FAIL \
+     --memory ${params.plink_memory} \
      --make-bed \
      --out ${name}_miss_filtered
    """
@@ -265,6 +269,7 @@ else if ( params.trait_type == "quantitative" )
      --bfile ${name}_filtered \
      --allow-no-sex \
      --missing \
+     --memory ${params.plink_memory} \
      --out ${name} \
      --1 \
      --keep-allele-order
@@ -275,6 +280,7 @@ else if ( params.trait_type == "quantitative" )
      --keep-allele-order \
      --allow-no-sex \
      --exclude ${name}.missing_FAIL \
+     --memory ${params.plink_memory} \
      --make-bed \
      --out ${name}_miss_filtered
   """
@@ -299,6 +305,7 @@ process calculate_hwe {
     --bfile ${name}_miss_filtered \
     --pheno $phe_file \
     --pheno-name ${params.phenotype_colname} \
+    --memory ${params.plink_memory} \
     --allow-no-sex \
     --hwe ${params.hwe_threshold} ${params.hwe_test} \
     --out ${name}.misHWEfiltered \
@@ -310,6 +317,7 @@ process calculate_hwe {
     --bfile ${name}.misHWEfiltered  \
     --keep-allele-order \
     --recode vcf-iid bgz \
+    --memory ${params.plink_memory} \
     --out ${name}_filtered_vcf
 
   bcftools view ${name}_filtered_vcf.vcf.gz | awk -F '\\t' 'NR==FNR{c[\$1\$4\$6\$5]++;next}; c[\$1\$2\$4\$5] > 0' ${name}.misHWEfiltered.bim - | bgzip > ${name}.filtered_temp.vcf.gz
@@ -345,6 +353,7 @@ if (!params.grm_plink_input) {
       --bfile \${bed_prefix} \
       --merge-list merge.list \
       --allow-no-sex \
+      --memory ${params.plink_memory} \
       --make-bed \
       --out merged
 
@@ -371,12 +380,14 @@ if (!params.grm_plink_input) {
       --indep-pairwise ${params.ld_window_size} ${params.ld_step_size} ${params.ld_r2_threshold} \
       --exclude range ${long_range_ld_regions} \
       --allow-no-sex \
+      --memory ${params.plink_memory} \
       --out merged
       plink \
       --bfile merged \
       --keep-allele-order \
       --extract merged.prune.in \
       --make-bed \
+      --memory ${params.plink_memory} \
       --allow-no-sex \
       --out merged_pruned 
       """

--- a/main.nf
+++ b/main.nf
@@ -205,6 +205,7 @@ if (params.genotype_format == 'vcf') {
 else if (params.genotype_format == 'bgen') {
   process bgen2plink {
     tag "$name"
+    label "mid_memory"
     publishDir "${params.outdir}/gwas_filtering", mode: 'copy'
 
     input:

--- a/main.nf
+++ b/main.nf
@@ -131,8 +131,8 @@ else if (params.genotype_files_list && params.genotype_format == 'bgen') {
   .set { ch_bgen_sample_file }
 
 }
-else if (!params.genotype_files_list) {
-  exit 1, "File containing paths to genotype files not specified. Please specify using --genotype_files_list parameter."
+else if (!params.genotype_files_list || !params.input_folder_location) {
+  exit 1, "File containing paths to genotype files not specified. Please specify a .csv file with paths using --genotype_files_list parameter, or a input s3 path using --input_folder_location parameter."
 }
 else if (params.genotype_format != 'vcf' && params.genotype_format != 'bgen') {
   exit 1, "Genotype format not supported. Please choose out of valid formats."

--- a/main.nf
+++ b/main.nf
@@ -165,7 +165,7 @@ if (params.run_pca) {
 if (params.genotype_format == 'vcf') {
   process vcf2plink {
   tag "$name"
-  label 'mega_memory'
+  label 'high_memory'
   publishDir "${params.outdir}/gwas_filtering", mode: 'copy'
 
   input:
@@ -190,6 +190,7 @@ if (params.genotype_format == 'vcf') {
     --vcf ${name}_filtered.vcf.gz \
     --out ${name}_filtered \
     --vcf-half-call m \
+    --memory ${params.plink_memory} \
     --double-id \
     --set-hh-missing \
     --new-id-max-allele-len 60 missing
@@ -222,6 +223,7 @@ else if (params.genotype_format == 'bgen') {
     --out ${name}_filtered \
     --maf ${params.maf_filter} \
     --double-id \
+    --memory ${params.plink_memory} \
     --keep samples.txt \
     --sample ${sample_file}
   """ 

--- a/main.nf
+++ b/main.nf
@@ -227,6 +227,7 @@ else if (params.genotype_format == 'bgen') {
 
 process filter_missingness {
   tag "$name"
+  label 'plink'
   publishDir "${params.outdir}/filter_miss", mode: 'copy'
   input:
   set val(name), val(chr), file(bed), file(bim), file(fam) from filteredPlinkCh

--- a/main.nf
+++ b/main.nf
@@ -131,7 +131,7 @@ else if (params.genotype_files_list && params.genotype_format == 'bgen') {
   .set { ch_bgen_sample_file }
 
 }
-else if (!params.genotype_files_list || !params.input_folder_location) {
+else if (!params.genotype_files_list && !params.input_folder_location) {
   exit 1, "File containing paths to genotype files not specified. Please specify a .csv file with paths using --genotype_files_list parameter, or a input s3 path using --input_folder_location parameter."
 }
 else if (params.genotype_format != 'vcf' && params.genotype_format != 'bgen') {

--- a/main.nf
+++ b/main.nf
@@ -228,7 +228,7 @@ else if (params.genotype_format == 'bgen') {
       --out ${name}_filtered \
       --maf ${params.maf_filter} \
       --double-id \
-      --memory $plink_memory \
+      --memory ${plink_memory} \
       --keep samples.txt \
       --sample ${sample_file}
     """ 
@@ -287,7 +287,7 @@ else if ( params.trait_type == "quantitative" )
      --keep-allele-order \
      --allow-no-sex \
      --exclude ${name}.missing_FAIL \
-     --memory ${task.memory} \
+     --memory ${plink_memory} \
      --make-bed \
      --out ${name}_miss_filtered
   """

--- a/main.nf
+++ b/main.nf
@@ -190,7 +190,6 @@ if (params.genotype_format == 'vcf') {
       --vcf ${name}_filtered.vcf.gz \
       --out ${name}_filtered \
       --vcf-half-call m \
-      --memory ${params.plink_memory} \
       --double-id \
       --set-hh-missing \
       --new-id-max-allele-len 60 missing
@@ -222,7 +221,6 @@ else if (params.genotype_format == 'bgen') {
       --out ${name}_filtered \
       --maf ${params.maf_filter} \
       --double-id \
-      --memory ${params.plink_memory} \
       --keep samples.txt \
       --sample ${sample_file}
     """ 
@@ -248,7 +246,6 @@ process filter_missingness {
      --pheno-name ${params.phenotype_colname} \
      --allow-no-sex \
      --test-missing midp \
-     --memory ${params.plink_memory} \
      --out ${name} \
      --1 \
      --keep-allele-order \
@@ -259,7 +256,6 @@ process filter_missingness {
      --keep-allele-order \
      --allow-no-sex \
      --exclude ${name}.missing_FAIL \
-     --memory ${params.plink_memory} \
      --make-bed \
      --out ${name}_miss_filtered
    """
@@ -269,7 +265,6 @@ else if ( params.trait_type == "quantitative" )
      --bfile ${name}_filtered \
      --allow-no-sex \
      --missing \
-     --memory ${params.plink_memory} \
      --out ${name} \
      --1 \
      --keep-allele-order
@@ -280,7 +275,6 @@ else if ( params.trait_type == "quantitative" )
      --keep-allele-order \
      --allow-no-sex \
      --exclude ${name}.missing_FAIL \
-     --memory ${params.plink_memory} \
      --make-bed \
      --out ${name}_miss_filtered
   """
@@ -305,7 +299,6 @@ process calculate_hwe {
     --bfile ${name}_miss_filtered \
     --pheno $phe_file \
     --pheno-name ${params.phenotype_colname} \
-    --memory ${params.plink_memory} \
     --allow-no-sex \
     --hwe ${params.hwe_threshold} ${params.hwe_test} \
     --out ${name}.misHWEfiltered \
@@ -317,7 +310,6 @@ process calculate_hwe {
     --bfile ${name}.misHWEfiltered  \
     --keep-allele-order \
     --recode vcf-iid bgz \
-    --memory ${params.plink_memory} \
     --out ${name}_filtered_vcf
 
   bcftools view ${name}_filtered_vcf.vcf.gz | awk -F '\\t' 'NR==FNR{c[\$1\$4\$6\$5]++;next}; c[\$1\$2\$4\$5] > 0' ${name}.misHWEfiltered.bim - | bgzip > ${name}.filtered_temp.vcf.gz
@@ -353,7 +345,6 @@ if (!params.grm_plink_input) {
       --bfile \${bed_prefix} \
       --merge-list merge.list \
       --allow-no-sex \
-      --memory ${params.plink_memory} \
       --make-bed \
       --out merged
 
@@ -380,14 +371,12 @@ if (!params.grm_plink_input) {
       --indep-pairwise ${params.ld_window_size} ${params.ld_step_size} ${params.ld_r2_threshold} \
       --exclude range ${long_range_ld_regions} \
       --allow-no-sex \
-      --memory ${params.plink_memory} \
       --out merged
       plink \
       --bfile merged \
       --keep-allele-order \
       --extract merged.prune.in \
       --make-bed \
-      --memory ${params.plink_memory} \
       --allow-no-sex \
       --out merged_pruned 
       """

--- a/main.nf
+++ b/main.nf
@@ -218,6 +218,7 @@ else if (params.genotype_format == 'bgen') {
     --make-bed \
     --bgen ${bgen}\
     --out ${name}_filtered \
+    --maf ${params.maf_filter} \
     --double-id \
     --keep samples.txt \
     --sample ${sample_file}

--- a/main.nf
+++ b/main.nf
@@ -249,6 +249,7 @@ process filter_missingness {
      --pheno-name ${params.phenotype_colname} \
      --allow-no-sex \
      --test-missing midp \
+     --memory ${params.plink_memory} \
      --out ${name} \
      --1 \
      --keep-allele-order \
@@ -259,6 +260,7 @@ process filter_missingness {
      --keep-allele-order \
      --allow-no-sex \
      --exclude ${name}.missing_FAIL \
+     --memory ${params.plink_memory} \
      --make-bed \
      --out ${name}_miss_filtered
    """
@@ -268,6 +270,7 @@ else if ( params.trait_type == "quantitative" )
      --bfile ${name}_filtered \
      --allow-no-sex \
      --missing \
+     --memory ${params.plink_memory} \
      --out ${name} \
      --1 \
      --keep-allele-order
@@ -278,6 +281,7 @@ else if ( params.trait_type == "quantitative" )
      --keep-allele-order \
      --allow-no-sex \
      --exclude ${name}.missing_FAIL \
+     --memory ${params.plink_memory} \
      --make-bed \
      --out ${name}_miss_filtered
   """
@@ -302,6 +306,7 @@ process calculate_hwe {
     --bfile ${name}_miss_filtered \
     --pheno $phe_file \
     --pheno-name ${params.phenotype_colname} \
+    --memory ${params.plink_memory} \
     --allow-no-sex \
     --hwe ${params.hwe_threshold} ${params.hwe_test} \
     --out ${name}.misHWEfiltered \
@@ -313,6 +318,7 @@ process calculate_hwe {
     --bfile ${name}.misHWEfiltered  \
     --keep-allele-order \
     --recode vcf-iid bgz \
+    --memory ${params.plink_memory} \
     --out ${name}_filtered_vcf
 
   bcftools view ${name}_filtered_vcf.vcf.gz | awk -F '\\t' 'NR==FNR{c[\$1\$4\$6\$5]++;next}; c[\$1\$2\$4\$5] > 0' ${name}.misHWEfiltered.bim - | bgzip > ${name}.filtered_temp.vcf.gz
@@ -348,6 +354,7 @@ if (!params.grm_plink_input) {
       --bfile \${bed_prefix} \
       --merge-list merge.list \
       --allow-no-sex \
+      --memory ${params.plink_memory} \
       --make-bed \
       --out merged
 
@@ -374,12 +381,14 @@ if (!params.grm_plink_input) {
       --indep-pairwise ${params.ld_window_size} ${params.ld_step_size} ${params.ld_r2_threshold} \
       --exclude range ${long_range_ld_regions} \
       --allow-no-sex \
+      --memory ${params.plink_memory} \
       --out merged
       plink \
       --bfile merged \
       --keep-allele-order \
       --extract merged.prune.in \
       --make-bed \
+      --memory ${params.plink_memory} \
       --allow-no-sex \
       --out merged_pruned 
       """

--- a/main.nf
+++ b/main.nf
@@ -165,6 +165,7 @@ if (params.run_pca) {
 if (params.genotype_format == 'vcf') {
   process vcf2plink {
   tag "$name"
+  label 'mega_memory'
   publishDir "${params.outdir}/gwas_filtering", mode: 'copy'
 
   input:
@@ -198,6 +199,7 @@ if (params.genotype_format == 'vcf') {
 else if (params.genotype_format == 'bgen') {
   process bgen2plink {
     tag "$name"
+    label 'mega_memory'
     publishDir "${params.outdir}/gwas_filtering", mode: 'copy'
 
     input:

--- a/main.nf
+++ b/main.nf
@@ -228,7 +228,6 @@ else if (params.genotype_format == 'bgen') {
 
 process filter_missingness {
   tag "$name"
-  label 'plink'
   publishDir "${params.outdir}/filter_miss", mode: 'copy'
   input:
   set val(name), val(chr), file(bed), file(bim), file(fam) from filteredPlinkCh

--- a/main.nf
+++ b/main.nf
@@ -220,6 +220,7 @@ else if (params.genotype_format == 'bgen') {
     --out ${name}_filtered \
     --double-id \
     --keep samples.txt \
+    --sample ${sample_file}
   """ 
 
   }

--- a/main.nf
+++ b/main.nf
@@ -220,7 +220,6 @@ else if (params.genotype_format == 'bgen') {
     --out ${name}_filtered \
     --double-id \
     --keep samples.txt \
-    --sample ${sample_file}
   """ 
 
   }

--- a/nextflow.config
+++ b/nextflow.config
@@ -60,8 +60,8 @@ params {
 
 
   // process resources defaults
-    cpus = 4
-    memory = 16.GB
+    cpus = 1
+    memory = 2.GB
     disk = '30.GB'
     
     // max resources limits defaults

--- a/nextflow.config
+++ b/nextflow.config
@@ -54,9 +54,35 @@ params {
   max_top_n_sites = 1000
   saige_filename_pattern = '.SAIGE.gwas.txt'
   config = 'conf/standard.config'
+
+
+  // process resources defaults
+    cpus = 1
+    memory = 2.GB
+    disk = '30.GB'
+    
+    // max resources limits defaults
+    max_cpus = 128
+    max_memory = 240.GB
+    max_time = 12.h
+    
+  // execution related defaults
+  echo = false
+  errorStrategy = 'finish'
+  maxRetries = 9
+  maxForks = 200
+  queueSize = 200
+  executor = false
 }
 
 process {
+
+    echo = params.echo
+    cpus = params.cpus
+    memory = params.memory
+    maxRetries = params.maxRetries
+    maxForks = params.maxForks
+    errorStrategy = params.errorStrategy
     container = 'quay.io/lifebitai/gwas:1.2dev'
 
   withLabel: saige {

--- a/nextflow.config
+++ b/nextflow.config
@@ -30,6 +30,7 @@ params {
   covariate_cols = false
 
   q_filter = '0.005:minor'
+  maf_filter = 0.05
   miss_test_p_threshold = '1e-5'
   variant_missingness = '0.01'
   hwe_threshold = '1e-5'
@@ -70,7 +71,7 @@ params {
   echo = false
   errorStrategy = 'finish'
   maxRetries = 9
-  maxForks = 20
+  maxForks = 200
   queueSize = 200
   executor = false
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -11,10 +11,6 @@ manifest {
 
 docker.enabled = true
 
-process {
-  cpus = 8
-}
-
 params {
   genotype_files_list = null
   genotype_format = "vcf"
@@ -78,6 +74,21 @@ params {
   executor = false
 }
 
+// Profiles
+
+profiles {
+  standard {includeConfig params.config }
+  base {includeConfig 'conf/base.config'}
+  test_binary { includeConfig 'conf/test_binary.config' }
+  test_binary_prune_pca { includeConfig 'conf/test_binary_prune_pca.config' }
+  test_binary_prune_no_pca { includeConfig 'conf/test_binary_prune_no_pca.config' }
+  test_binary_with_input_folder { includeConfig 'conf/test_binary_with_input_folder.config' }
+  test_binary_bgen { includeConfig 'conf/test_binary_bgen.config' }
+  test_qt { includeConfig 'conf/test_qt.config' }
+}
+
+// Process scope
+
 process {
 
     echo = params.echo
@@ -95,17 +106,4 @@ process {
   withName: create_report {
      cpus = 2
   }
-}
-
-// Profiles
-
-profiles {
-  standard {includeConfig params.config }
-  base {includeConfig 'conf/base.config'}
-  test_binary { includeConfig 'conf/test_binary.config' }
-  test_binary_prune_pca { includeConfig 'conf/test_binary_prune_pca.config' }
-  test_binary_prune_no_pca { includeConfig 'conf/test_binary_prune_no_pca.config' }
-  test_binary_with_input_folder { includeConfig 'conf/test_binary_with_input_folder.config' }
-  test_binary_bgen { includeConfig 'conf/test_binary_bgen.config' }
-  test_qt { includeConfig 'conf/test_qt.config' }
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -16,7 +16,8 @@ process {
 }
 
 params {
-  
+  genotype_files_list = null
+  genotype_format = "vcf"
   vcfs_list = false
   input_folder_location = null
   file_pattern = null

--- a/nextflow.config
+++ b/nextflow.config
@@ -46,7 +46,7 @@ params {
 }
 
 process {
-    container = 'quay.io/lifebitai/biobank-gwas:1.1dev'
+    container = 'quay.io/lifebitai/gwas:1.2dev'
 
   withLabel: saige {
     container = 'quay.io/lifebitai/saige:0.39'

--- a/nextflow.config
+++ b/nextflow.config
@@ -12,7 +12,7 @@ manifest {
 docker.enabled = true
 
 process {
-  cpus = 1
+  cpus = 8
 }
 
 params {

--- a/nextflow.config
+++ b/nextflow.config
@@ -60,8 +60,8 @@ params {
 
 
   // process resources defaults
-    cpus = 2
-    memory = 4.GB
+    cpus = 4
+    memory = 16.GB
     disk = '30.GB'
     
     // max resources limits defaults

--- a/nextflow.config
+++ b/nextflow.config
@@ -40,8 +40,6 @@ params {
   run_pca = true
   number_pcs = 10
 
-  plink_memory = 16000
-
   trait_type = 'binary'
   saige_step1_extra_flags = "--LOCO=FALSE"
   outdir = 'results'

--- a/nextflow.config
+++ b/nextflow.config
@@ -59,10 +59,6 @@ params {
 process {
     container = 'quay.io/lifebitai/gwas:1.2dev'
 
-  withLabel: plink {
-    container = 'quay.io/lifebitai/plink1:latest'
-  }
-
   withLabel: saige {
     container = 'quay.io/lifebitai/saige:0.39'
   }
@@ -79,5 +75,6 @@ profiles {
   test_binary_prune_pca { includeConfig 'conf/test_binary_prune_pca.config' }
   test_binary_prune_no_pca { includeConfig 'conf/test_binary_prune_no_pca.config' }
   test_binary_with_input_folder { includeConfig 'conf/test_binary_with_input_folder.config' }
+  test_binary_bgen { includeConfig 'conf/test_binary_bgen.config' }
   test_qt { includeConfig 'conf/test_qt.config' }
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -70,7 +70,7 @@ params {
   echo = false
   errorStrategy = 'finish'
   maxRetries = 9
-  maxForks = 200
+  maxForks = 20
   queueSize = 200
   executor = false
 }
@@ -83,6 +83,7 @@ process {
     maxRetries = params.maxRetries
     maxForks = params.maxForks
     errorStrategy = params.errorStrategy
+
     container = 'quay.io/lifebitai/gwas:1.2dev'
 
   withLabel: saige {

--- a/nextflow.config
+++ b/nextflow.config
@@ -70,7 +70,7 @@ params {
   // execution related defaults
   echo = false
   errorStrategy = 'finish'
-  maxRetries = 9
+  maxRetries = 1
   maxForks = 200
   queueSize = 200
   executor = false
@@ -99,6 +99,7 @@ process {
 
 profiles {
   standard {includeConfig params.config }
+  base {includeConfig 'conf/base.config'}
   test_binary { includeConfig 'conf/test_binary.config' }
   test_binary_prune_pca { includeConfig 'conf/test_binary_prune_pca.config' }
   test_binary_prune_no_pca { includeConfig 'conf/test_binary_prune_no_pca.config' }

--- a/nextflow.config
+++ b/nextflow.config
@@ -40,6 +40,8 @@ params {
   run_pca = true
   number_pcs = 10
 
+  plink_memory = 16000
+
   trait_type = 'binary'
   saige_step1_extra_flags = "--LOCO=FALSE"
   outdir = 'results'

--- a/nextflow.config
+++ b/nextflow.config
@@ -44,6 +44,8 @@ params {
   run_pca = true
   number_pcs = 10
 
+  plink_memory = 155000
+
   trait_type = 'binary'
   saige_step1_extra_flags = "--LOCO=FALSE"
   outdir = 'results'
@@ -63,9 +65,9 @@ params {
     disk = '30.GB'
     
     // max resources limits defaults
-    max_cpus = 128
+    max_cpus = 32
     max_memory = 240.GB
-    max_time = 12.h
+    max_time = 8.h
     
   // execution related defaults
   echo = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -44,7 +44,7 @@ params {
   run_pca = true
   number_pcs = 10
 
-  plink_memory = 155000
+  plink_memory = 16000
 
   trait_type = 'binary'
   saige_step1_extra_flags = "--LOCO=FALSE"

--- a/nextflow.config
+++ b/nextflow.config
@@ -18,6 +18,12 @@ process {
 params {
   
   vcfs_list = false
+  input_folder_location = null
+  file_pattern = null
+  file_suffix = "vcf.gz"
+  index_suffix = "vcf.gz.csi"
+  number_of_files_to_process = -1
+
   grm_plink_input = false
   pheno_data = false
   covariate_cols = false
@@ -33,12 +39,16 @@ params {
   ld_step_size = 10
   ld_r2_threshold = 0.1
 
+  run_pca = true
+  number_pcs = 10
+
   trait_type = 'binary'
   saige_step1_extra_flags = "--LOCO=FALSE"
   outdir = 'results'
   gwas_cat = 's3://lifebit-featured-datasets/projects/gel/gel-gwas/gwascat.csv'
   phenotype_colname = "PHE"
   output_tag = null
+  p_significance_threshold = 0.01
   top_n_sites = 200
   max_top_n_sites = 1000
   saige_filename_pattern = '.SAIGE.gwas.txt'
@@ -61,5 +71,8 @@ process {
 profiles {
   standard {includeConfig params.config }
   test_binary { includeConfig 'conf/test_binary.config' }
+  test_binary_prune_pca { includeConfig 'conf/test_binary_prune_pca.config' }
+  test_binary_prune_no_pca { includeConfig 'conf/test_binary_prune_no_pca.config' }
+  test_binary_with_input_folder { includeConfig 'conf/test_binary_with_input_folder.config' }
   test_qt { includeConfig 'conf/test_qt.config' }
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -60,8 +60,8 @@ params {
 
 
   // process resources defaults
-    cpus = 1
-    memory = 2.GB
+    cpus = 2
+    memory = 4.GB
     disk = '30.GB'
     
     // max resources limits defaults

--- a/nextflow.config
+++ b/nextflow.config
@@ -59,6 +59,10 @@ params {
 process {
     container = 'quay.io/lifebitai/gwas:1.2dev'
 
+  withLabel: plink {
+    container = 'quay.io/lifebitai/plink1:latest'
+  }
+
   withLabel: saige {
     container = 'quay.io/lifebitai/saige:0.39'
   }


### PR DESCRIPTION
## Overview

This PR:
- Adds support for accepting .bgen files + accompanying .sample file as input
- Updates `--vcfs_list` to `genotype_files_list` with a new parameter - `genotype_format` with current options being `vcf` and `bgen`.
- New `--bgen_sample_file` to accept accompanying .sample file.
- New `bgen2plink` step that performs bgen-> plink conversion and subsets to samples present in `pheno_data` file.
- Small modification to change lambda to greek letter representation in QQ plot
-  Updates `docs/usage_and_parameters.md` with new/updated params

## Test

Lifebit CloudOS (Internal Production workspace)

https://cloudos.lifebit.ai/app/jobs/619b837afb26cf01dcee30de