### PR TITLE
{EG} add analysis mode to SAIGE

### DIFF
--- a/docs/usage_and_parameters.md
+++ b/docs/usage_and_parameters.md
@@ -64,6 +64,7 @@ OR vcf files can be supplied using:
 - **--number_pcs** : Number of principal components generated ans used in GWAS. Default=`10`.
 
 - **--saige_step1_extra_flags** : Additional flags for SAIGE, they should be formatted as "--LOCO=FALSE".
+- **--saige_analysis_type** : Analysis mode for SAIGE GWAS. Options are `additive`, `dominant` and `recessive`. Default = `additive`.
 - **--outdir** : Output directory for results.
 - **--gwas_cat** : Path to GWAS catalog CSV file. Defaults to 's3://lifebit-featured-datasets/projects/gel/gel-gwas/gwascat.csv'.
 - **--output_tag** : Prefix to identify output files.

--- a/main.nf
+++ b/main.nf
@@ -45,6 +45,7 @@ summary['variant_missingness']            = params.variant_missingness
 summary['hwe_threshold']                  = params.hwe_threshold
 summary['trait_type']                     = params.trait_type
 summary['saige_step1_extra_flags']        = params.saige_step1_extra_flags
+summary['saige_analysis_type']            = params.saige_analysis_type
 summary['gwas_cat']                       = params.gwas_cat
 summary['output_tag']                     = params.output_tag
 summary['top_n_sites']                    = params.top_n_sites

--- a/main.nf
+++ b/main.nf
@@ -127,7 +127,7 @@ else exit 1, "Trait type is not recognised. Please check input for --trait_type 
 params.output_tag ? Channel.value(params.output_tag).into {ch_output_tag_report; ch_output_tag } : Channel.value(params.phenotype_colname).into {ch_output_tag_report; ch_output_tag }
 
 saige_analysis_list = defineSaigeAnalysisTypeList()
-saige_analysis = params.saige_analysis_list
+saige_analysis = params.saige_analysis_type
 if (saige_analysis.contains(',')) exit 1, 'You can choose only one analysis model, see --help for more information'
 if (!checkParameterExistence(saige_analysis, saige_analysis_list)) exit 1, "Unknown analysis mode: ${saige_analysis}, see --help for more information"
 

--- a/main.nf
+++ b/main.nf
@@ -68,8 +68,25 @@ def get_chromosome( file ) {
     
 }
 
+def checkParameterExistence(it, list) {
+    if (!list.contains(it)) {
+        log.warn "Unknown parameter: ${it}"
+        return false
+    }
+    return true
+}
+
 def checkParameterList(list, realList) {
     return list.every{ checkParameterExistence(it, realList) }
+}
+
+def defineSaigeAnalysisTypeList() {
+    return [
+        'additive',
+        'recessive',
+        'dominant'
+
+    ]
 }
 
 def defineFormatList() {
@@ -107,6 +124,11 @@ else exit 1, "Trait type is not recognised. Please check input for --trait_type 
 
 
 params.output_tag ? Channel.value(params.output_tag).into {ch_output_tag_report; ch_output_tag } : Channel.value(params.phenotype_colname).into {ch_output_tag_report; ch_output_tag }
+
+saige_analysis_list = defineSaigeAnalysisTypeList()
+saige_analysis = params.saige_analysis_list
+if (saige_analysis.contains(',')) exit 1, 'You can choose only one analysis model, see --help for more information'
+if (!checkParameterExistence(saige_analysis, saige_analysis_list)) exit 1, "Unknown analysis mode: ${saige_analysis}, see --help for more information"
 
 
 ch_pheno = params.pheno_data ? Channel.value(file(params.pheno_data)) : Channel.empty()
@@ -614,6 +636,7 @@ process gwas_2_spa_tests {
     --IsOutputAFinCaseCtrl=TRUE \
     --IsDropMissingDosages=FALSE \
     --IsOutputNinCaseCtrl=TRUE \
+    --analysisType=${params.saige_analysis_type} \
     --IsOutputHetHomCountsinCaseCtrl=TRUE
   """
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -55,6 +55,7 @@ params {
 
   trait_type = 'binary'
   saige_step1_extra_flags = "--LOCO=FALSE"
+  saige_analysis_type = "additive"
   outdir = 'results'
   gwas_cat = 's3://lifebit-featured-datasets/projects/gel/gel-gwas/gwascat.csv'
   phenotype_colname = "PHE"


### PR DESCRIPTION
## Overview

- This PR adds `--saige_analysis_type` option to association testing SAIGE process

## Changes

- adds `saige_analysis_type` to `nextflow.config`
- adds to docs
- adds parameter validation restring to `additive`, `recessive` and `dominant`.
- sets `additive` as default

## Test

